### PR TITLE
Feature: Sync Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Added `Resources` struct.
+- Added `Resource` trait.
+- Added `AccessError` enum.
+- Added `Ref` struct.
+- Added `RefMut` struct.

--- a/CREDIT.md
+++ b/CREDIT.md
@@ -1,0 +1,14 @@
+# Credit
+
+This crate uses the following libraries as inspiration, and / or heavily
+referenced their code.
+
+### [Legion](https://crates.io/crates/legion/0.4.0)
+
+This crate was created as a stand-alone replacement for Legion's `Resoruces` 
+struct.  As such, Legion's code was heavily referenced during development.
+
+- [**Commit**](https://github.com/amethyst/legion/tree/v0.4.0)
+- **License**: MIT
+- **Code Used**: The `Resources` struct, and it's supporting types, found in
+  [`resources.rs`](https://github.com/amethyst/legion/blob/32df916517fa3b3bb5d827d824053bbb128a43be/src/internals/systems/resources.rs),

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Shared Resources 
 
+[![CI](https://github.com/AlexiWolf/shared_resources/actions/workflows/ci.yml/badge.svg)](https://github.com/AlexiWolf/shared_resources/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/l/shared_resources)](https://github.com/AlexiWolf/shared_resources#license)
+[![Crates.io](https://img.shields.io/crates/v/shared_resources)](https://crates.io/crates/shared_resources)
+
 Provides a `Resource` container, which safe access to a collection of
 resources. These resources are added at run-time by the user.  The store can 
 hold most types, and can contain up to 1 instance of each type.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ usage.
 
 ## Status
 
-Shared Resources is currently in very early development.  You should expect 
-missing features, bugs, changing APIs, and other spooky stuff until release 
-1.0.
+Shared Resources is mostly complete, but is not quite ready for release yet.
+Things may still change until release 1.0. 
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 [![Crates.io](https://img.shields.io/crates/l/shared_resources)](https://github.com/AlexiWolf/shared_resources#license)
 [![Crates.io](https://img.shields.io/crates/v/shared_resources)](https://crates.io/crates/shared_resources)
 
-Provides a `Resource` container, which safe access to a collection of
-resources. These resources are added at run-time by the user.  The store can 
-hold most types, and can contain up to 1 instance of each type.
+This crate provides a `Resources` struct, which stores a collection of
+`Resoruce` types added in at run-time. The store contains up to 1 of each
+type, can be shared between threads, and provides safe, concurrent access to 
+shared resources.  The API is lock-free, and borrowing rules are checked at
+run-time.
+
+The design is based heavily on the `Resources` struct found in 
+[Legion](https://crates.io/crates/legion).  It also takes ideas from
+the [Resources](https://crates.io/crates/resources) crate, and combines them
+into a library that's stand-alone, and generally more well-behaved for general
+usage.
 
 ## Status
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -132,6 +132,14 @@ mod tests {
         assert_eq!(borrow_a.unwrap_err(), AccessError::NoSuchResource);
         assert_eq!(borrow_b.unwrap_err(), AccessError::NoSuchResource);
     }
+
+    #[test]
+    fn should_use_sync_handle() {
+        let mut resources = Resources::default();
+        resources.insert(TestResource("Hello, World!"));
+
+        let resources_sync = resources.sync();
+    }
 }
 
 /// Provides a [`Resource`] container which does run-time borrow-checking, but *does not* ensure

--- a/src/store.rs
+++ b/src/store.rs
@@ -73,6 +73,10 @@ pub struct ResourcesSync<'a> {
     inner: &'a Resources,
 }
 
+// # Safety
+//
+// Access to stored resources is restricted to `Send`, and `Sync` types only.  Making access to 
+// `!Send`, and `!Sync` types on other threads impossible. 
 unsafe impl<'a> Send for ResourcesSync<'a> {}
 unsafe impl<'a> Sync for ResourcesSync<'a> {}
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -81,6 +81,8 @@ impl<'a> ResourcesSync<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::thread;
+
     use super::*;
 
     #[derive(Debug)]
@@ -153,6 +155,10 @@ mod tests {
         resources.insert(TestResource("Hello, World!"));
 
         let resources_sync = resources.sync();
+
+        let handle = thread::spawn(|| {
+            let resource = resources_sync.get::<TestResource>().unwrap();
+        });
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -43,8 +43,7 @@ impl Resources {
     /// - Returns [`AccessError::AlreadyBorrowed`] if there is an existing mutable reference to
     ///   `T`.
     pub fn get<T: Resource>(&self) -> Result<Ref<T>, AccessError> {
-        // Safety: `Resources` is `!Send` / `!Sync`, so it is not possible for it to access the
-        // `UnsafeResources` store from another thread.
+        // Safety: `Resources` is `!Send` / `!Sync`, so it is impossible to send it across threads.
         unsafe { self.inner.try_borrow::<T>() }
     }
 
@@ -55,8 +54,7 @@ impl Resources {
     /// - Returns [`AccessError::NoSuchResource`] if an instance of type `T` does not exist.
     /// - Returns [`AccessError::AlreadyBorrowed`] if there is an existing reference to `T`.
     pub fn get_mut<T: Resource>(&self) -> Result<RefMut<T>, AccessError> {
-        // Safety: `Resources` is `!Send` / `!Sync`, so it is not possible for it to modify the
-        // `UnsafeResources` store on another thread.
+        // Safety: `Resources` is `!Send` / `!Sync`, so it is impossible to send it across threads.
         unsafe { self.inner.try_borrow_mut::<T>() }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -65,6 +65,10 @@ impl Resources {
     }
 }
 
+pub struct ResourcesSync<'a> {
+    inner: &'a Resources,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/store.rs
+++ b/src/store.rs
@@ -31,6 +31,10 @@ impl Resources {
         }
     }
 
+    pub fn sync(&self) -> ResourcesSync {
+        ResourcesSync::new(&self.inner)
+    }
+
     /// Returns an immutable reference to the stored `T`, if it exists.
     ///
     /// # Errors

--- a/src/store.rs
+++ b/src/store.rs
@@ -73,6 +73,9 @@ pub struct ResourcesSync<'a> {
     inner: &'a Resources,
 }
 
+unsafe impl<'a> Send for ResourcesSync<'a> {}
+unsafe impl<'a> Sync for ResourcesSync<'a> {}
+
 impl<'a> ResourcesSync<'a> {
     pub(crate) fn new(inner: &'a Resources) -> Self {
         Self { inner }

--- a/src/store.rs
+++ b/src/store.rs
@@ -96,8 +96,6 @@ impl<'a> ResourcesSync<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
-
     use super::*;
 
     #[derive(Debug)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -188,14 +188,17 @@ mod tests {
         let mut resources = Resources::default();
         resources.insert(TestResource("Hello, World!"));
         let resources_sync = resources.sync();
-        {
-            let mut resource = resources_sync.get_mut::<TestResource>().unwrap();
-            resource.0 = "Goodbye, World!";
-        }
-        {
-            let resource = resources_sync.get::<TestResource>().unwrap();
-            assert_eq!(resource.0, "Goodbye, World!");
-        }
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                let mut resource = resources_sync.get_mut::<TestResource>().unwrap();
+                resource.0 = "Goodbye, World!";
+            }).join().unwrap();
+            scope.spawn(|| {
+                let resource = resources_sync.get::<TestResource>().unwrap();
+                assert_eq!(resource.0, "Goodbye, World!");
+            }).join().unwrap();
+        });
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -167,7 +167,7 @@ mod tests {
 
         let resources_sync = resources.sync();
 
-        let handle = thread::spawn(|| {
+        let handle = thread::spawn(move || {
             let resource = resources_sync.get::<TestResource>().unwrap();
         });
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -92,6 +92,14 @@ impl<'a> ResourcesSync<'a> {
             None => Err(AccessError::NoSuchResource),
         }
     }
+
+    pub fn get_mut<T: Resource + Send>(&self) -> Result<RefMut<T>, AccessError> {
+        let type_id = TypeId::of::<T>();
+        match unsafe { self.inner.get(&type_id) } {
+            Some(cell) => Ok(cell.try_borrow_mut::<T>()?),
+            None => Err(AccessError::NoSuchResource),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -32,7 +32,7 @@ impl Resources {
     }
 
     pub fn sync(&self) -> ResourcesSync {
-        ResourcesSync::new(&self.inner)
+        ResourcesSync::new(&self)
     }
 
     /// Returns an immutable reference to the stored `T`, if it exists.
@@ -71,6 +71,12 @@ impl Resources {
 
 pub struct ResourcesSync<'a> {
     inner: &'a Resources,
+}
+
+impl<'a> ResourcesSync<'a> {
+    pub(crate) fn new(inner: &'a Resources) -> Self {
+        Self { inner }
+    }
 }
 
 #[cfg(test)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -69,19 +69,19 @@ impl Resources {
     }
 }
 
-pub struct ResourcesSync<'a> {
-    inner: &'a Resources,
+pub struct ResourcesSync {
+    inner: &'static Resources,
 }
 
 // # Safety
 //
 // Access to stored resources is restricted to `Send`, and `Sync` types only.  Making access to 
 // `!Send`, and `!Sync` types on other threads impossible. 
-unsafe impl<'a> Send for ResourcesSync<'a> {}
-unsafe impl<'a> Sync for ResourcesSync<'a> {}
+unsafe impl Send for ResourcesSync {}
+unsafe impl Sync for ResourcesSync {}
 
-impl<'a> ResourcesSync<'a> {
-    pub(crate) fn new(inner: &'a Resources) -> Self {
+impl ResourcesSync {
+    pub(crate) fn new(inner: &'static Resources) -> Self {
         Self { inner }
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -77,6 +77,10 @@ impl<'a> ResourcesSync<'a> {
     pub(crate) fn new(inner: &'a Resources) -> Self {
         Self { inner }
     }
+
+    pub fn get<T: Resource + Sync>(&self) -> Result<Ref<T>, AccessError> {
+        self.inner.get::<T>()
+    }
 }
 
 #[cfg(test)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -85,6 +85,13 @@ impl<'a> ResourcesSync<'a> {
         Self { inner }
     }
 
+    /// Returns an immutable reference to the stored `T`, if it exists.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`AccessError::NoSuchResource`] if an instance of type `T` does not exist.
+    /// - Returns [`AccessError::AlreadyBorrowed`] if there is an existing mutable reference to
+    ///   `T`.
     pub fn get<T: Resource + Sync>(&self) -> Result<Ref<T>, AccessError> {
         let type_id = TypeId::of::<T>();
         match unsafe { self.inner.get(&type_id) } {
@@ -93,6 +100,12 @@ impl<'a> ResourcesSync<'a> {
         }
     }
 
+    /// Returns an immutable reference to the stored `T`, if it exists.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`AccessError::NoSuchResource`] if an instance of type `T` does not exist.
+    /// - Returns [`AccessError::AlreadyBorrowed`] if there is an existing reference to `T`.
     pub fn get_mut<T: Resource + Send>(&self) -> Result<RefMut<T>, AccessError> {
         let type_id = TypeId::of::<T>();
         match unsafe { self.inner.get(&type_id) } {

--- a/src/store.rs
+++ b/src/store.rs
@@ -170,6 +170,7 @@ mod tests {
         let handle = thread::spawn(move || {
             let resource = resources_sync.get::<TestResource>().unwrap();
         });
+        handle.join();
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -170,8 +170,12 @@ mod tests {
         resources.insert(TestResource("Hello, World!"));
         let resources_sync = resources.sync();
         {
+            let mut resource = resources_sync.get_mut::<TestResource>().unwrap();
+            resource.0 = "Goodbye, World!";
+        }
+        {
             let resource = resources_sync.get::<TestResource>().unwrap();
-            assert_eq!(resource.0, "Hello, World!");
+            assert_eq!(resource.0, "Goodbye, World!");
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -89,6 +89,8 @@ impl<'a> ResourcesSync<'a> {
     /// - Returns [`AccessError::AlreadyBorrowed`] if there is an existing mutable reference to
     ///   `T`.
     pub fn get<T: Resource + Sync>(&self) -> Result<Ref<T>, AccessError> {
+        // Safety: This function only allows access to resources which are `Sync`, so it is
+        // impossible to access `!Sync` resources across threads.
         unsafe { self.inner.try_borrow::<T>() }
     }
 
@@ -99,6 +101,8 @@ impl<'a> ResourcesSync<'a> {
     /// - Returns [`AccessError::NoSuchResource`] if an instance of type `T` does not exist.
     /// - Returns [`AccessError::AlreadyBorrowed`] if there is an existing reference to `T`.
     pub fn get_mut<T: Resource + Send>(&self) -> Result<RefMut<T>, AccessError> {
+        // Safety: This function only allows access to resources which are `Send`, so it is
+        // impossible to access `!Send` resources across threads.
         unsafe { self.inner.try_borrow_mut::<T>() }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -168,13 +168,11 @@ mod tests {
     fn should_use_sync_handle() {
         let mut resources = Resources::default();
         resources.insert(TestResource("Hello, World!"));
-
         let resources_sync = resources.sync();
-
-        let handle = thread::spawn(move || {
+        {
             let resource = resources_sync.get::<TestResource>().unwrap();
-        });
-        handle.join();
+            assert_eq!(resource.0, "Hello, World!");
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the `ResourcesSync` struct, a thread-safe version of the `Resources` struct.  A `ResourcesSync` instance can be created by calling `Resources::sync()`.

# Changes Made

All notable changes introduced by this PR should be documented here.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

- Added `ResourcesSync` struct.
- Added `Resources::sync()` method.

# Merge Checklist

This is the standard checklist of tasks that **MUST** be completed before a PR
can be accepted.

- [x] New behaviors are covered by tests, and / or examples.
- [x] The documentation has been updated (if applicable.)
- [x] The version number has been bumped (if applicable.)
- [x] The feature branch is up to date with `main`. 
